### PR TITLE
add platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,20 @@
+[platformio]
+src_dir = Core/Src
+include_dir = Core/Inc
+
+[env]
+platform = ststm32
+upload_protocol = stlink
+monitor_speed = 115200
+
+board = 
+board_build.ldscript = 
+
+build_flags = 
+    -DUSE_HAL_DRIVERS
+    -Wall 
+    -Wextra 
+    -Wpedantic 
+    -Werror
+build_src_filter = 
+


### PR DESCRIPTION
# Purpose
Added platformio.ini file inside template

# Overview
The platformio.ini file is fully set up with everything required for a generic STM32 PlatformIO project to build. However, a few fields need to be filled out by the user of the template, as they are specific to each individual project.