### PR TITLE
fix: USE_HAL_DRIVERS -> USE_HAL_DRIVER in platformio.ini (#8)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,7 +11,7 @@ board =
 board_build.ldscript = 
 
 build_flags = 
-    -DUSE_HAL_DRIVERS
+    -DUSE_HAL_DRIVER
     -Wall 
     -Wextra 
     -Wpedantic 


### PR DESCRIPTION
Fixes build configuration issue by correcting the STM32 HAL driver define name.

The macro `USE_HAL_DRIVERS` (with trailing 'S') is incorrect - the standard STM32 convention is `USE_HAL_DRIVER` (without 'S').

Fixes #8